### PR TITLE
Fix validation for select

### DIFF
--- a/wain-validate/src/insn.rs
+++ b/wain-validate/src/insn.rs
@@ -432,12 +432,12 @@ impl<'outer, 'm, 's, S: Source> ValidateInsnSeq<'outer, 'm, 's, S> for Instructi
             }
             // https://webassembly.github.io/spec/core/valid/instructions.html#valid-select
             Select => {
-                ctx.pop_op_stack(Type::Unknown)?;
-                ctx.pop_op_stack(Type::Unknown)?;
                 ctx.pop_op_stack(Type::i32())?;
+                let ty = ctx.pop_op_stack(Type::Unknown)?;
+                ctx.pop_op_stack(ty)?;
                 // 'select' instruction is value-polymorphic. The value pushed here is
                 // one of the first or second value. The value is checked dynamically
-                ctx.op_stack.push(Type::Unknown);
+                ctx.op_stack.push(ty);
             }
             // https://webassembly.github.io/spec/core/valid/instructions.html#valid-local-get
             LocalGet(localidx) => {


### PR DESCRIPTION
1. The type check for i32 should be applied to the 3rd operand, not the 1st operand.

    The sample code below should be accepted by validator.
    `(module (func (export "_start") (select (i64.const 1) (i64.const 1) (i32.const 1)) (drop)))`

2. The 1st and 2nd operands should have a same type.

    The sample code below should be rejected by validator.
    `(module (func (export "_start") (select (i32.const 1) (i64.const 1) (i32.const 1)) (drop)))`

3. The result type should have a same type to the 1st and 2nd operands.

    The sample code below should be rejected by validator rather than cause runtime error.
    `(module (func (export "_start") (i32.eqz (select (i64.const 1) (i64.const 1) (i32.const 1))) (drop)))`