### PR TITLE
Fix custom section check

### DIFF
--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -171,10 +171,8 @@ impl<'s> Parser<'s> {
     // ignored since it is not necessary to execute wasm binary.
     fn ignore_custom_sections(&mut self) -> Result<'s, ()> {
         while let [0, ..] = self.input {
-            self.eat(1); // Eat section ID
-            let size = self.parse_int::<u32>()? as usize;
-            self.check_len(size, "custom section")?;
-            self.eat(size);
+            let mut inner = self.section_parser()?;
+            let _: Name = inner.parse()?;
         }
         Ok(())
     }


### PR DESCRIPTION
The name of custom sections should be checked.

Passed new 180 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/custom.wast":
  total: 14, passed: 12, failed: 2, skipped: 0

End ".../wain/spec-test/wasm-testsuite/utf8-custom-section-id.wast":
  total: 177, passed: 1, failed: 176, skipped: 0

End ".../wain/spec-test/wasm-testsuite/binary-leb128.wast":
  total: 107, passed: 102, failed: 5, skipped: 0

Results of 76 files:
  total: 19740, passed: 19046, failed: 498, skipped: 196
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/custom.wast":
  total: 14, passed: 14, failed: 0, skipped: 0

End ".../wain/spec-test/wasm-testsuite/utf8-custom-section-id.wast":
  total: 177, passed: 177, failed: 0, skipped: 0

End ".../wain/spec-test/wasm-testsuite/binary-leb128.wast":
  total: 107, passed: 104, failed: 3, skipped: 0

Results of 76 files:
  total: 19740, passed: 19226, failed: 318, skipped: 196
```
