### PR TITLE
Fix binary parser and label stack behavior

### DIFF
--- a/wain-syntax-binary/src/error.rs
+++ b/wain-syntax-binary/src/error.rs
@@ -31,6 +31,8 @@ pub enum ErrorKind {
         num_funcs: usize,
         num_codes: usize,
     },
+    TooManyLocalVariables,
+    MalformedSectionSize,
     ExpectedEof(u8),
 }
 
@@ -128,6 +130,8 @@ impl<'s> fmt::Display for Error<'s> {
                 "number of function sections '{}' does not match to number of code sections '{}'",
                 num_funcs, num_codes,
             )?,
+            TooManyLocalVariables => write!(f, "too many local variables")?,
+            MalformedSectionSize => write!(f, "malformed section size")?,
             ExpectedEof(b) => write!(
                 f,
                 "expected end of input but byte 0x{:02x} is still following",

--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -965,7 +965,7 @@ impl<'s> Parse<'s> for Code {
             locals_check.push(loc);
         }
 
-        let mut locals = vec![];
+        let mut locals = Vec::with_capacity(count as usize);
         for loc in locals_check {
             locals.resize(locals.len() + loc.count as usize, loc.ty);
         }

--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -953,21 +953,14 @@ impl<'s> Parse<'s> for Code {
         let mut inner = parser.sub_parser(size, "code section")?;
         parser.eat(size);
 
-        let mut locals_check = vec![];
-        let mut count = 0u32;
+        let mut locals = vec![];
         for loc in inner.parse_vec::<Locals>()? {
             let loc = loc?;
-            if let Some(c) = count.checked_add(loc.count) {
-                count = c;
+            if let Some(c) = loc.count.checked_add(locals.len() as u32) {
+                locals.resize(c as usize, loc.ty);
             } else {
                 return Err(parser.error(ErrorKind::TooManyLocalVariables));
             }
-            locals_check.push(loc);
-        }
-
-        let mut locals = Vec::with_capacity(count as usize);
-        for loc in locals_check {
-            locals.resize(locals.len() + loc.count as usize, loc.ty);
         }
 
         let Expr(expr) = inner.parse()?;

--- a/wain-validate/src/insn.rs
+++ b/wain-validate/src/insn.rs
@@ -251,7 +251,7 @@ pub(crate) fn validate_func_body<'outer, 'm, 's, S: Source>(
         current_offset: start,
         outer,
         op_stack: vec![],
-        label_stack: vec![],
+        label_stack: vec![ret_ty],
         current_frame: CtrlFrame {
             height: 0,
             offset: start,


### PR DESCRIPTION
Check input length before check version.
Check local variable count before expand types.
Check section size.
Push function's return type to label stack.

Passed new 84 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/binary.wast":
  total: 85, passed: 17, failed: 1, skipped: 67

Results of 76 files:
  total: 19740, passed: 19046, failed: 498, skipped: 196
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/binary.wast":
  total: 102, passed: 101, failed: 1, skipped: 0

Results of 76 files:
  total: 19757, passed: 19130, failed: 498, skipped: 129
```
