### PR TITLE
Fix decimal float parser

### DIFF
--- a/wain-syntax-text/src/parser.rs
+++ b/wain-syntax-text/src/parser.rs
@@ -262,6 +262,22 @@ impl<'s> ParseContext<'s> {
     }
 }
 
+trait IsInfinite: Copy {
+    fn is_infinite(self) -> bool;
+}
+
+impl IsInfinite for f32 {
+    fn is_infinite(self) -> bool {
+        self.is_infinite()
+    }
+}
+
+impl IsInfinite for f64 {
+    fn is_infinite(self) -> bool {
+        self.is_infinite()
+    }
+}
+
 // TODO: Add index-to-id tables for types, funcs, tables, mems, globals, locals and labels
 // https://webassembly.github.io/spec/core/text/modules.html#indices
 pub struct Parser<'s> {
@@ -452,7 +468,7 @@ impl<'s> Parser<'s> {
         offset: usize,
     ) -> Result<'s, F>
     where
-        F: FromStr + ops::Neg<Output = F>,
+        F: FromStr + ops::Neg<Output = F> + IsInfinite,
         F::Err: fmt::Display,
     {
         // TODO: Implement parsing floating number literals without allocation
@@ -467,6 +483,9 @@ impl<'s> Parser<'s> {
             }
         }
         match s.parse::<F>() {
+            Ok(f) if f.is_infinite() => {
+                self.cannot_parse_num("float", "float constant out of range", offset)
+            }
             Ok(f) => Ok(sign.apply(f)),
             Err(e) => self.cannot_parse_num("float", format!("{}", e), offset),
         }

--- a/wain-syntax-text/src/parser.rs
+++ b/wain-syntax-text/src/parser.rs
@@ -262,7 +262,7 @@ impl<'s> ParseContext<'s> {
     }
 }
 
-trait IsInfinite: Copy {
+trait IsInfinite {
     fn is_infinite(self) -> bool;
 }
 
@@ -468,7 +468,7 @@ impl<'s> Parser<'s> {
         offset: usize,
     ) -> Result<'s, F>
     where
-        F: FromStr + ops::Neg<Output = F> + IsInfinite,
+        F: FromStr + ops::Neg<Output = F> + IsInfinite + Copy,
         F::Err: fmt::Display,
     {
         // TODO: Implement parsing floating number literals without allocation


### PR DESCRIPTION
Parsing decimal float should cause error if the result is infinite.

Passed new 8 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/const.wast":
  total: 767, passed: 759, failed: 8, skipped: 0

Results of 76 files:
  total: 19740, passed: 19046, failed: 498, skipped: 196
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/const.wast":
  total: 767, passed: 767, failed: 0, skipped: 0

Results of 76 files:
  total: 19740, passed: 19054, failed: 490, skipped: 196
```
