### PR TITLE
Fix func-code consistency check for binary format

### DIFF
--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -378,6 +378,11 @@ impl<'s> Parse<'s> for Module<'s> {
                 }
             }
             inner.ensure_empty()?
+        } else if !func_indices.is_empty() {
+            return Err(parser.error(ErrorKind::FuncCodeLengthMismatch {
+                num_funcs: func_indices.len(),
+                num_codes: 0,
+            }));
         }
 
         parser.ignore_custom_sections()?;


### PR DESCRIPTION
Check func count == 0 if code count == 0

Passed new one test.

**before**
```
End ".../wain/spec-test/wasm-testsuite/binary.wast":
  total: 102, passed: 101, failed: 1, skipped: 0

Results of 76 files:
  total: 19757, passed: 19393, failed: 235, skipped: 129
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/binary.wast":
  total: 102, passed: 102, failed: 0, skipped: 0

Results of 76 files:
  total: 19757, passed: 19394, failed: 234, skipped: 129
```
