### PR TITLE
Fix TypeUse

### DIFF
--- a/wain-ast/src/lib.rs
+++ b/wain-ast/src/lib.rs
@@ -46,6 +46,7 @@ pub struct Import<'s> {
 }
 
 // https://webassembly.github.io/spec/core/syntax/types.html#function-types
+#[derive(Clone)]
 pub struct FuncType {
     pub start: usize,
     pub params: Vec<ValType>,

--- a/wain-syntax-text/src/ast.rs
+++ b/wain-syntax-text/src/ast.rs
@@ -36,6 +36,7 @@ pub struct Module<'s> {
     pub memories: Vec<Memory<'s>>,
     pub globals: Vec<Global<'s>>,
     pub entrypoint: Option<Start<'s>>,
+    pub tentatives: Vec<u32>,
 }
 
 // https://webassembly.github.io/spec/core/text/modules.html#text-typedef
@@ -47,6 +48,7 @@ pub struct TypeDef<'s> {
 }
 
 // https://webassembly.github.io/spec/core/text/types.html#text-functype
+#[derive(Clone)]
 #[cfg_attr(test, derive(Debug))]
 pub struct FuncType<'s> {
     pub start: usize,
@@ -97,11 +99,23 @@ pub struct Import {
 #[cfg_attr(test, derive(Debug))]
 pub struct Name(pub String);
 
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub enum RefOrInline<'s> {
+    Reference(Index<'s>),
+    Inline(u32),
+}
+
 // https://webassembly.github.io/spec/core/text/modules.html#type-uses
 #[cfg_attr(test, derive(Debug))]
 pub struct TypeUse<'s> {
     pub start: usize,
-    pub idx: Index<'s>,
+    pub idx: RefOrInline<'s>,
+    pub params: Vec<Param<'s>>,
+    pub results: Vec<FuncResult>,
+}
+
+pub struct TentativeTypeUse<'s> {
+    pub start: usize,
     pub params: Vec<Param<'s>>,
     pub results: Vec<FuncResult>,
 }

--- a/wain-syntax-text/src/ast.rs
+++ b/wain-syntax-text/src/ast.rs
@@ -36,7 +36,7 @@ pub struct Module<'s> {
     pub memories: Vec<Memory<'s>>,
     pub globals: Vec<Global<'s>>,
     pub entrypoint: Option<Start<'s>>,
-    pub tentatives: Vec<u32>,
+    pub implicit_type_uses: Vec<u32>,
 }
 
 // https://webassembly.github.io/spec/core/text/modules.html#text-typedef
@@ -100,21 +100,21 @@ pub struct Import {
 pub struct Name(pub String);
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
-pub enum RefOrInline<'s> {
-    Reference(Index<'s>),
-    Inline(u32),
+pub enum TypeUseKind<'s> {
+    Explicit(Index<'s>),
+    Implicit(u32),
 }
 
 // https://webassembly.github.io/spec/core/text/modules.html#type-uses
 #[cfg_attr(test, derive(Debug))]
 pub struct TypeUse<'s> {
     pub start: usize,
-    pub idx: RefOrInline<'s>,
+    pub idx: TypeUseKind<'s>,
     pub params: Vec<Param<'s>>,
     pub results: Vec<FuncResult>,
 }
 
-pub struct TentativeTypeUse<'s> {
+pub struct ImplicitTypeUse<'s> {
     pub start: usize,
     pub params: Vec<Param<'s>>,
     pub results: Vec<FuncResult>,

--- a/wain-syntax-text/src/parser.rs
+++ b/wain-syntax-text/src/parser.rs
@@ -494,6 +494,7 @@ impl<'s> Parser<'s> {
             Err(e) => self.cannot_parse_num("float", format!("{}", e), offset),
         }
     }
+
     fn create_inline_typeuse(
         &mut self,
         start: usize,
@@ -508,6 +509,7 @@ impl<'s> Parser<'s> {
         });
         idx as u32
     }
+
     fn resolve_tentatives(&mut self) -> Vec<u32> {
         // Handle abbreviation:
         //   https://webassembly.github.io/spec/core/text/modules.html#abbreviations

--- a/wain-syntax-text/src/wat2wasm.rs
+++ b/wain-syntax-text/src/wat2wasm.rs
@@ -20,6 +20,7 @@ pub enum TransformErrorKind<'source> {
         label: Option<&'source str>,
         id: &'source str,
     },
+    FuncTypeMismatch,
 }
 
 #[cfg_attr(test, derive(Debug))]
@@ -72,6 +73,7 @@ impl<'s> fmt::Display for TransformError<'s> {
                 "in control instruction, label None and identifier '{}' must be the same",
                 id
             )?,
+            FuncTypeMismatch => write!(f, "function type mismatch")?,
         }
 
         describe_position(f, self.source, self.offset)
@@ -176,18 +178,20 @@ struct Context<'s> {
     local_indices: Indices<'s>,
     next_local_idx: u32,
     label_stack: LabelStack<'s>,
+    tentatives: Vec<u32>,
+    types: Vec<wat::FuncType<'s>>,
 }
 
 impl<'s> Context<'s> {
     fn resolve_index(
         &self,
         indices: &Indices,
-        idx: wat::Index<'s>,
+        idx: &wat::Index<'s>,
         offset: usize,
         what: &'static str,
     ) -> Result<'s, u32> {
         match idx {
-            wat::Index::Num(i) => Ok(i),
+            wat::Index::Num(i) => Ok(*i),
             wat::Index::Ident(id) => {
                 if let Some(idx) = indices.get(id) {
                     Ok(*idx)
@@ -202,24 +206,57 @@ impl<'s> Context<'s> {
         }
     }
 
-    fn resolve_type_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.type_indices, idx, offset, "type")
+    fn resolve_type_idx(&mut self, ty: &wat::TypeUse<'s>, offset: usize) -> Result<'s, u32> {
+        match &ty.idx {
+            wat::RefOrInline::Reference(idx) => {
+                let idx = self.resolve_index(&self.type_indices, idx, offset, "type")?;
+                if idx as usize >= self.types.len() {
+                    return Ok(idx);
+                }
+                let wat::FuncType {
+                    params, results, ..
+                } = &self.types[idx as usize];
+                if ty.params.is_empty() && ty.results.is_empty()
+                    || ty.params.len() == params.len()
+                        && ty.results.len() == results.len()
+                        && ty
+                            .params
+                            .iter()
+                            .zip(params.iter())
+                            .all(|(l, r)| l.ty == r.ty)
+                        && ty
+                            .results
+                            .iter()
+                            .zip(results.iter())
+                            .all(|(l, r)| l.ty == r.ty)
+                {
+                    Ok(idx)
+                } else {
+                    Err(TransformError::new(
+                        TransformErrorKind::FuncTypeMismatch,
+                        offset,
+                        self.source,
+                    ))
+                }
+            }
+            wat::RefOrInline::Inline(idx) => Ok(self.tentatives[*idx as usize]),
+        }
     }
 
     fn resolve_func_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.func_indices, idx, offset, "function")
+        self.resolve_index(&self.func_indices, &idx, offset, "function")
     }
 
     fn resolve_table_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.table_indices, idx, offset, "table")
+        self.resolve_index(&self.table_indices, &idx, offset, "table")
     }
 
     fn resolve_mem_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.mem_indices, idx, offset, "memory")
+        self.resolve_index(&self.mem_indices, &idx, offset, "memory")
     }
 
     fn resolve_global_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.global_indices, idx, offset, "global")
+        self.resolve_index(&self.global_indices, &idx, offset, "global")
     }
 
     fn start_func_scope(&mut self) {
@@ -247,12 +284,12 @@ impl<'s> Context<'s> {
     }
 
     fn resolve_local_idx(&self, idx: wat::Index<'s>, offset: usize) -> Result<'s, u32> {
-        self.resolve_index(&self.local_indices, idx, offset, "local variable")
+        self.resolve_index(&self.local_indices, &idx, offset, "local variable")
     }
 }
 
 pub fn wat2wasm<'s>(
-    parsed: wat::Parsed<'s>,
+    mut parsed: wat::Parsed<'s>,
     source: &'s str,
 ) -> Result<'s, wasm::Root<'s, TextSource<'s>>> {
     let mut ctx = Context {
@@ -265,6 +302,8 @@ pub fn wat2wasm<'s>(
         local_indices: Indices::new(),
         next_local_idx: 0,
         label_stack: LabelStack::new(source),
+        tentatives: std::mem::replace(&mut parsed.module.tentatives, Vec::new()),
+        types: Vec::new(),
     };
     let module = parsed.module.transform(&mut ctx)?;
     Ok(wasm::Root {
@@ -295,6 +334,13 @@ impl<'s, T: Transform<'s>> Transform<'s> for Option<T> {
 impl<'s> Transform<'s> for wat::Module<'s> {
     type Target = wasm::Module<'s>;
     fn transform(self, ctx: &mut Context<'s>) -> Result<'s, Self::Target> {
+        ctx.types.append(
+            &mut self
+                .types
+                .iter()
+                .map(|wat::TypeDef { ty, .. }| ty.clone())
+                .collect(),
+        );
         Ok(wasm::Module {
             start: self.start,
             id: self.id,
@@ -326,20 +372,22 @@ impl<'s> Transform<'s> for wat::ValType {
 impl<'s> Transform<'s> for wat::TypeDef<'s> {
     type Target = wasm::FuncType;
     fn transform(self, ctx: &mut Context<'s>) -> Result<'s, Self::Target> {
+        let params = self
+            .ty
+            .params
+            .iter()
+            .map(|p| p.ty.transform(ctx))
+            .collect::<Result<'_, _>>()?;
+        let results = self
+            .ty
+            .results
+            .iter()
+            .map(|p| p.ty.transform(ctx))
+            .collect::<Result<'_, _>>()?;
         Ok(wasm::FuncType {
             start: self.start,
-            params: self
-                .ty
-                .params
-                .iter()
-                .map(|p| p.ty.transform(ctx))
-                .collect::<Result<'_, _>>()?,
-            results: self
-                .ty
-                .results
-                .iter()
-                .map(|p| p.ty.transform(ctx))
-                .collect::<Result<'_, _>>()?,
+            params,
+            results,
         })
     }
 }
@@ -470,7 +518,7 @@ impl<'s> Transform<'s> for wat::Instruction<'s> {
             wat::InsnKind::Return => wasm::InsnKind::Return,
             wat::InsnKind::Call(idx) => wasm::InsnKind::Call(ctx.resolve_func_idx(idx, start)?),
             wat::InsnKind::CallIndirect(ty) => {
-                wasm::InsnKind::CallIndirect(ctx.resolve_type_idx(ty.idx, start)?)
+                wasm::InsnKind::CallIndirect(ctx.resolve_type_idx(&ty, start)?)
             }
             // Parametric instructions
             wat::InsnKind::Drop => wasm::InsnKind::Drop,
@@ -666,7 +714,7 @@ impl<'s> Transform<'s> for wat::Func<'s> {
     fn transform(self, ctx: &mut Context<'s>) -> Result<'s, Self::Target> {
         Ok(wasm::Func {
             start: self.start,
-            idx: ctx.resolve_type_idx(self.ty.idx, self.start)?,
+            idx: ctx.resolve_type_idx(&self.ty, self.start)?,
             kind: match self.kind {
                 wat::FuncKind::Import(import) => wasm::FuncKind::Import(import.transform(ctx)?),
                 wat::FuncKind::Body { locals, body } => {


### PR DESCRIPTION
Inline parameter and result declaration without typeidx should insert
type definition at the last of module.

Inline parameter and result declaration with typeidx should check
consistency.

Passed new 10 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/func.wast":
  total: 130, passed: 124, failed: 6, skipped: 0

End ".../wain/spec-test/wasm-testsuite/call_indirect.wast":
  total: 153, passed: 149, failed: 4, skipped: 0

Results of 76 files:
  total: 19757, passed: 19416, failed: 212, skipped: 129
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/func.wast":
  total: 130, passed: 130, failed: 0, skipped: 0

End ".../wain/spec-test/wasm-testsuite/call_indirect.wast":
  total: 153, passed: 153, failed: 0, skipped: 0

Results of 76 files:
  total: 19757, passed: 19426, failed: 202, skipped: 129
```
