### PR TITLE
Fix constant expression

### DIFF
--- a/wain-ast/src/lib.rs
+++ b/wain-ast/src/lib.rs
@@ -37,6 +37,7 @@ pub struct Module<'s> {
     pub memories: Vec<Memory<'s>>,
     pub globals: Vec<Global<'s>>,
     pub entrypoint: Option<StartFunction>,
+    pub import_globals_len: u32,
 }
 
 // https://webassembly.github.io/spec/core/syntax/modules.html#syntax-module

--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -277,6 +277,7 @@ impl<'s> Parse<'s> for Module<'s> {
             }
             inner.ensure_empty()?;
         }
+        let import_globals_len = globals.len() as u32;
 
         parser.ignore_custom_sections()?;
 
@@ -407,6 +408,7 @@ impl<'s> Parse<'s> for Module<'s> {
             memories,
             globals,
             entrypoint,
+            import_globals_len,
         })
     }
 }

--- a/wain-syntax-text/src/ast.rs
+++ b/wain-syntax-text/src/ast.rs
@@ -37,6 +37,7 @@ pub struct Module<'s> {
     pub globals: Vec<Global<'s>>,
     pub entrypoint: Option<Start<'s>>,
     pub implicit_type_uses: Vec<u32>,
+    pub import_globals_len: u32,
 }
 
 // https://webassembly.github.io/spec/core/text/modules.html#text-typedef

--- a/wain-syntax-text/src/parser.rs
+++ b/wain-syntax-text/src/parser.rs
@@ -859,6 +859,7 @@ impl<'s> Parse<'s> for Module<'s> {
         let mut memories = vec![];
         let mut globals = vec![];
         let mut entrypoint = None;
+        let mut import_globals_len = 0;
 
         // Any import must be put before other definitions because indices of imports must precede
         // indices of other definitions
@@ -913,7 +914,10 @@ impl<'s> Parse<'s> for Module<'s> {
                         global.start,
                     );
                 }
-                ModuleField::Import(ImportItem::Global(global)) => globals.push(global),
+                ModuleField::Import(ImportItem::Global(global)) => {
+                    import_globals_len += 1;
+                    globals.push(global)
+                }
                 ModuleField::Export(export) => parser.ctx.exports.push(export),
                 ModuleField::Func(func) => {
                     if let FuncKind::Body { .. } = func.kind {
@@ -982,6 +986,8 @@ impl<'s> Parse<'s> for Module<'s> {
                             ParseErrorKind::ImportMustPrecedeOtherDefs { what: "global" },
                             global.start,
                         );
+                    } else {
+                        import_globals_len += 1;
                     }
                     globals.push(global);
                 }
@@ -1026,6 +1032,7 @@ impl<'s> Parse<'s> for Module<'s> {
             globals,
             entrypoint,
             implicit_type_uses,
+            import_globals_len,
         })
     }
 }

--- a/wain-syntax-text/src/wat2wasm.rs
+++ b/wain-syntax-text/src/wat2wasm.rs
@@ -348,6 +348,7 @@ impl<'s> Transform<'s> for wat::Module<'s> {
             memories: self.memories.transform(ctx)?,
             globals: self.globals.transform(ctx)?,
             entrypoint: self.entrypoint.transform(ctx)?,
+            import_globals_len: self.import_globals_len,
         })
     }
 }

--- a/wain-validate/src/insn.rs
+++ b/wain-validate/src/insn.rs
@@ -633,7 +633,8 @@ pub(crate) fn validate_constant<'m, 's, S: Source>(
     let name = insn.kind.name();
     let ty = match &insn.kind {
         GlobalGet(globalidx) => {
-            if let Some(global) = ctx.module.globals.get(*globalidx as usize) {
+            if *globalidx < ctx.module.import_globals_len {
+                let global = ctx.module.globals.get(*globalidx as usize).unwrap();
                 if global.mutable {
                     return ctx.error(ErrorKind::MutableForConstant(*globalidx), when, start);
                 } else {
@@ -644,7 +645,7 @@ pub(crate) fn validate_constant<'m, 's, S: Source>(
                     .error(
                         ErrorKind::IndexOutOfBounds {
                             idx: *globalidx,
-                            upper: ctx.module.globals.len(),
+                            upper: ctx.module.import_globals_len as usize,
                             what: "global variable read",
                         },
                         "",


### PR DESCRIPTION
Only imported global variables should be used in a constant expression.

Passed new 4 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/globals.wast":
  total: 79, passed: 76, failed: 3, skipped: 0

End ".../wain/spec-test/wasm-testsuite/global.wast":
  total: 82, passed: 79, failed: 3, skipped: 0

Results of 76 files:
  total: 19757, passed: 19426, failed: 202, skipped: 129
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/globals.wast":
  total: 79, passed: 78, failed: 1, skipped: 0

End ".../wain/spec-test/wasm-testsuite/global.wast":
  total: 82, passed: 81, failed: 1, skipped: 0

Results of 76 files:
  total: 19757, passed: 19430, failed: 198, skipped: 129
```