### PR TITLE
Fix instantiate

### DIFF
--- a/spec-test/src/runner.rs
+++ b/spec-test/src/runner.rs
@@ -524,10 +524,7 @@ impl<'a> Tester<'a> {
             }) => {
                 validate(root)?;
                 let importer = DefaultImporter::with_stdio(Discard, Discard);
-                let mut machine = Machine::instantiate(&root.module, importer).map_err(|err| {
-                    Error::run_error(RunKind::Trapped(*err), self.source, root.module.start)
-                })?;
-                match machine.execute() {
+                match Machine::instantiate(&root.module, importer) {
                     Ok(_) => Err(Error::run_error(
                         RunKind::InvokeTrapExpected {
                             ret: None,


### PR DESCRIPTION
Move invoking start function from execute method to instantiate method.
Change assert_trap to match the above changes.

Passed new 6 tests.

**before**
```
End ".../wain/spec-test/wasm-testsuite/start.wast":
  total: 21, passed: 12, failed: 9, skipped: 0

Results of 76 files:
  total: 19757, passed: 19426, failed: 202, skipped: 129
```

**after**
```
End ".../wain/spec-test/wasm-testsuite/start.wast":
  total: 21, passed: 18, failed: 3, skipped: 0

Results of 76 files:
  total: 19757, passed: 19432, failed: 196, skipped: 129
```