### PR TITLE
Fix the align argument of the memory instructions

### DIFF
--- a/wain-ast/src/lib.rs
+++ b/wain-ast/src/lib.rs
@@ -162,8 +162,8 @@ pub struct Instruction {
 
 // https://webassembly.github.io/spec/core/syntax/instructions.html#syntax-memarg
 pub struct Mem {
-    pub align: Option<u8>, // TODO: Change this to Option<u32>
-    pub offset: Option<u32>,
+    pub align: u32,
+    pub offset: u32,
 }
 
 // https://webassembly.github.io/spec/core/syntax/instructions.html#instructions

--- a/wain-exec/src/machine.rs
+++ b/wain-exec/src/machine.rs
@@ -339,11 +339,8 @@ impl<'m, 's, I: Importer> Machine<'m, 's, I> {
     }
 
     fn mem_addr(&mut self, mem: &ast::Mem) -> usize {
-        let mut addr = self.stack.pop::<i32>() as usize;
-        if let Some(off) = mem.offset {
-            addr += off as usize;
-        }
-        addr
+        let addr = self.stack.pop::<i32>() as usize;
+        addr + mem.offset as usize
     }
 
     fn load<V: LittleEndian>(&mut self, mem: &ast::Mem, at: usize) -> Result<V> {

--- a/wain-syntax-binary/src/parser.rs
+++ b/wain-syntax-binary/src/parser.rs
@@ -857,10 +857,8 @@ impl<'s> Parse<'s> for Instruction {
 // https://webassembly.github.io/spec/core/binary/instructions.html#binary-memarg
 impl<'s> Parse<'s> for Mem {
     fn parse(parser: &mut Parser<'s>) -> Result<'s, Self> {
-        let align: u32 = parser.parse_int()?;
+        let align = parser.parse_int()?;
         let offset = parser.parse_int()?;
-        let align = if align == 0 { None } else { Some(align as u8) };
-        let offset = if offset == 0 { None } else { Some(offset) };
         Ok(Mem { align, offset })
     }
 }

--- a/wain-syntax-text/src/ast.rs
+++ b/wain-syntax-text/src/ast.rs
@@ -215,8 +215,8 @@ pub struct Instruction<'s> {
 // https://webassembly.github.io/spec/core/text/instructions.html#text-memarg
 #[cfg_attr(test, derive(Debug))]
 pub struct Mem {
-    pub align: Option<u8>,
-    pub offset: Option<u32>,
+    pub align: u32,
+    pub offset: u32,
 }
 
 #[cfg_attr(test, derive(Debug))]

--- a/wain-validate/src/error.rs
+++ b/wain-validate/src/error.rs
@@ -25,8 +25,8 @@ pub enum ErrorKind {
         idx: u32,
     },
     TooLargeAlign {
-        align: u8,
-        bits: u8,
+        align: u32,
+        bits: u32,
     },
     InvalidLimitRange(u32, u32),
     LimitsOutOfRange {

--- a/wain-validate/src/lib.rs
+++ b/wain-validate/src/lib.rs
@@ -26,7 +26,11 @@ struct Context<'module, 'source: 'module, S: Source> {
 
 impl<'m, 's, S: Source> Context<'m, 's, S> {
     pub fn new(module: &'m Module<'s>, source: &'m S) -> Context<'m, 's, S> {
-        let num_import_globals = module.globals.iter().take_while(|g| matches!(g.kind, GlobalKind::Import(_))).count();
+        let num_import_globals = module
+            .globals
+            .iter()
+            .take_while(|g| matches!(g.kind, GlobalKind::Import(_)))
+            .count();
         Context {
             module,
             source,


### PR DESCRIPTION
The align argument should be an exponential value.
If there is no align argument, it should be the default value.
