### PR TITLE
Fix label handling

### DIFF
--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -479,7 +479,7 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
                 match body.execute(runtime)? {
                     ExecState::Continue => {}
                     ExecState::Ret => return Ok(ExecState::Ret),
-                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, *ty),
+                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, ty.is_some()),
                     ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                 }
             }
@@ -492,7 +492,7 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
                     match body.execute(runtime)? {
                         ExecState::Continue => break,
                         ExecState::Ret => return Ok(ExecState::Ret),
-                        ExecState::Breaking(0) => runtime.stack.pop_label(&label, None),
+                        ExecState::Breaking(0) => runtime.stack.pop_label(&label, false),
                         ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                     }
                 }
@@ -509,7 +509,7 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
                 match insns.execute(runtime)? {
                     ExecState::Continue => {}
                     ExecState::Ret => return Ok(ExecState::Ret),
-                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, *ty),
+                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, ty.is_some()),
                     ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                 }
             }

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -475,30 +475,28 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             // Control instructions
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-block
             Block { ty, body } => {
-                let label = runtime.stack.push_label(*ty);
+                let label = runtime.stack.push_label();
                 match body.execute(runtime)? {
                     ExecState::Continue => {}
                     ExecState::Ret => return Ok(ExecState::Ret),
-                    ExecState::Breaking(0) => {}
+                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, *ty),
                     ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                 }
-                runtime.stack.pop_label(label);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-loop
-            Loop { ty, body } => loop {
-                // Note: Difference between block and loop is the position on breaking. When reaching
-                // to the end of instruction sequence, loop instruction ends execution of subsequence.
-                let label = runtime.stack.push_label(*ty);
-                match body.execute(runtime)? {
-                    ExecState::Continue => {
-                        runtime.stack.pop_label(label);
-                        break;
+            Loop { body, .. } => {
+                let label = runtime.stack.push_label();
+                loop {
+                    // Note: Difference between block and loop is the position on breaking. When reaching
+                    // to the end of instruction sequence, loop instruction ends execution of subsequence.
+                    match body.execute(runtime)? {
+                        ExecState::Continue => break,
+                        ExecState::Ret => return Ok(ExecState::Ret),
+                        ExecState::Breaking(0) => runtime.stack.pop_label(&label, None),
+                        ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                     }
-                    ExecState::Ret => return Ok(ExecState::Ret),
-                    ExecState::Breaking(0) => continue,
-                    ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                 }
-            },
+            }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-if
             If {
                 ty,
@@ -506,15 +504,14 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
                 else_body,
             } => {
                 let cond: i32 = runtime.stack.pop();
-                let label = runtime.stack.push_label(*ty);
+                let label = runtime.stack.push_label();
                 let insns = if cond != 0 { then_body } else { else_body };
                 match insns.execute(runtime)? {
                     ExecState::Continue => {}
                     ExecState::Ret => return Ok(ExecState::Ret),
-                    ExecState::Breaking(0) => {}
+                    ExecState::Breaking(0) => runtime.stack.pop_label(&label, *ty),
                     ExecState::Breaking(level) => return Ok(ExecState::Breaking(level - 1)),
                 }
-                runtime.stack.pop_label(label);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-unreachable
             Unreachable => return Err(Trap::new(TrapReason::ReachUnreachable, self.start)),

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -199,9 +199,9 @@ impl Stack {
         }
     }
 
-    pub fn pop_label(&mut self, label: &Label, ty: Option<ValType>) {
+    pub fn pop_label(&mut self, label: &Label, has_result: bool) {
         // Part of 'br' instruction: https://webassembly.github.io/spec/core/exec/instructions.html#exec-br
-        if ty.is_some() {
+        if has_result {
             let v: Value = self.pop();
             self.restore(label.addr, label.type_idx);
             self.push(v);

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -192,17 +192,16 @@ impl Stack {
         self.types.truncate(type_idx);
     }
 
-    pub fn push_label(&self, ty: Option<ValType>) -> Label {
+    pub fn push_label(&self) -> Label {
         Label {
             addr: self.top_addr(),
             type_idx: self.top_idx(),
-            has_result: ty.is_some(),
         }
     }
 
-    pub fn pop_label(&mut self, label: Label) {
+    pub fn pop_label(&mut self, label: &Label, ty: Option<ValType>) {
         // Part of 'br' instruction: https://webassembly.github.io/spec/core/exec/instructions.html#exec-br
-        if label.has_result {
+        if ty.is_some() {
             let v: Value = self.pop();
             self.restore(label.addr, label.type_idx);
             self.push(v);
@@ -278,7 +277,6 @@ impl<'f> CallFrame<'f> {
 pub struct Label {
     addr: usize,
     type_idx: usize,
-    has_result: bool,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix:
- At the `Loop` instruction, the current implementation simply `continue`s
  when repeating (`ExecState::Breaking(0)`), but the `pop_label` should be
  called to free the operand stack.

Refactor:
- The current implementation saves the result type to the `Label` by
  `push_label`, but there is no need to save the result type to the `Label`
  because it can be referred to by `pop_label`.
- At the `Loop` instruction, the current implementation calls `push_label`
  at each iteration, but it only needs to be called once before the
  iteration begins because the content of the `Label` does not change at
  each iteration.
- At the `Block`, `Loop` and `If` instructions, there is no need to call
  `pop_label` if `ExecState` is `Continue`.