### PR TITLE
Refactor callframe

### DIFF
--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -254,16 +254,9 @@ impl<'m, 's, I: Importer> Runtime<'m, 's, I> {
             }
         }
 
-        if fty.results.is_empty() {
-            self.stack.pop_frame(prev_frame);
-            Ok(false)
-        } else {
-            // Push 1st result value since number of result type is 1 or 0 for MVP
-            let v: Value = self.stack.pop();
-            self.stack.pop_frame(prev_frame);
-            self.stack.push(v); // push result value
-            Ok(true)
-        }
+        let has_result = !fty.results.is_empty();
+        self.stack.pop_frame(prev_frame, has_result);
+        Ok(has_result)
     }
 
     // Invoke function by name

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -241,8 +241,7 @@ impl<'m, 's, I: Importer> Runtime<'m, 's, I> {
             ast::FuncKind::Body { locals, expr } => (locals, expr),
         };
 
-        let frame = self.stack.create_call_frame(&fty.params, &locals);
-        let prev_frame = self.stack.push_frame(frame);
+        let prev_frame = self.stack.push_frame(&fty.params, &locals);
 
         for insn in body {
             match insn.execute(self)? {

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -572,8 +572,8 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             // Variable instructions
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-get
             LocalGet(localidx) => {
-                let addr = runtime.stack.frame.local_addr(*localidx);
-                match runtime.stack.frame.local_type(&runtime.stack, *localidx) {
+                let addr = runtime.stack.local_addr(*localidx);
+                match runtime.stack.local_type(*localidx) {
                     ast::ValType::I32 => runtime.stack.push(runtime.stack.read::<i32>(addr)),
                     ast::ValType::I64 => runtime.stack.push(runtime.stack.read::<i64>(addr)),
                     ast::ValType::F32 => runtime.stack.push(runtime.stack.read::<f32>(addr)),
@@ -582,14 +582,14 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-set
             LocalSet(localidx) => {
-                let addr = runtime.stack.frame.local_addr(*localidx);
+                let addr = runtime.stack.local_addr(*localidx);
                 let val = runtime.stack.pop();
                 runtime.stack.write_any(addr, val);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-tee
             LocalTee(localidx) => {
                 // Like local.set, but it does not change stack
-                let addr = runtime.stack.frame.local_addr(*localidx);
+                let addr = runtime.stack.local_addr(*localidx);
                 let val = runtime.stack.top();
                 runtime.stack.write_any(addr, val);
             }

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -240,8 +240,14 @@ impl Stack {
         )
     }
 
-    pub fn pop_frame(&mut self, prev_frame: CallFrame) {
-        self.restore(self.frame.base_addr, self.frame.base_idx);
+    pub fn pop_frame(&mut self, prev_frame: CallFrame, has_result: bool) {
+        self.pop_label(
+            &Label {
+                addr: self.frame.base_addr,
+                type_idx: self.frame.base_idx,
+            },
+            has_result,
+        );
         self.frame = prev_frame;
     }
 

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -212,7 +212,7 @@ impl Stack {
         }
     }
 
-    pub fn create_call_frame(&mut self, params: &[ValType], locals: &[ValType]) -> CallFrame {
+    pub fn push_frame(&mut self, params: &[ValType], locals: &[ValType]) -> CallFrame {
         let mut local_addrs = Vec::with_capacity(params.len() + locals.len());
 
         // Note: Params were already pushed to stack
@@ -230,15 +230,14 @@ impl Stack {
 
         self.bytes.resize(addr, 0);
 
-        CallFrame {
-            base_addr,
-            base_idx,
-            local_addrs,
-        }
-    }
-
-    pub fn push_frame(&mut self, new_frame: CallFrame) -> CallFrame {
-        mem::replace(&mut self.frame, new_frame)
+        mem::replace(
+            &mut self.frame,
+            CallFrame {
+                base_addr,
+                base_idx,
+                local_addrs,
+            },
+        )
     }
 
     pub fn pop_frame(&mut self, prev_frame: CallFrame) {

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -14,6 +14,7 @@ use wain_ast::{AsValType, ValType};
 pub struct Stack {
     bytes: Vec<u8>,      // Bytes buffer for actual values
     types: Vec<ValType>, // this stack is necessary to pop arbitrary value
+    pub frame: CallFrame,
 }
 
 pub trait StackAccess: Sized {

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -245,6 +245,15 @@ impl Stack {
         self.restore(self.frame.base_addr, self.frame.base_idx);
         self.frame = prev_frame;
     }
+
+    pub fn local_addr(&self, localidx: u32) -> usize {
+        self.frame.local_addrs[localidx as usize]
+    }
+
+    pub fn local_type(&self, localidx: u32) -> ValType {
+        let idx = localidx as usize;
+        self.types[self.frame.base_idx + idx]
+    }
 }
 
 // Activations of function frames
@@ -255,17 +264,6 @@ pub struct CallFrame {
     base_addr: usize,
     base_idx: usize,
     local_addrs: Vec<usize>, // Calculate local addresses in advance for random access
-}
-
-impl CallFrame {
-    pub fn local_addr(&self, localidx: u32) -> usize {
-        self.local_addrs[localidx as usize]
-    }
-
-    pub fn local_type(&self, stack: &Stack, localidx: u32) -> ValType {
-        let idx = localidx as usize;
-        stack.types[self.base_idx + idx]
-    }
 }
 
 pub struct Label {


### PR DESCRIPTION
こないだちょっとお話していた、`Runtime` に持っている `CallFrame` を `Stack` に移動させるものです。
あわせて、`pop_frame` で関数の戻り値の処理もさせるように変更しています。
（`pop_label` の処理と同じだったので）