### PR TITLE
Remove address dependency

### DIFF
--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -574,14 +574,13 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-set
             LocalSet(localidx) => {
-                let val = runtime.stack.pop();
-                runtime.stack.write_local(*localidx, val);
+                runtime.stack.write_local(*localidx);
+                let _val: Value = runtime.stack.pop();
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-tee
             LocalTee(localidx) => {
                 // Like local.set, but it does not change stack
-                let val = runtime.stack.top();
-                runtime.stack.write_local(*localidx, val);
+                runtime.stack.write_local(*localidx);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-global-get
             GlobalGet(globalidx) => match runtime.module.ast.globals[*globalidx as usize].ty {

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -564,13 +564,7 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             // Variable instructions
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-get
             LocalGet(localidx) => {
-                let addr = runtime.stack.local_addr(*localidx);
-                match runtime.stack.local_type(*localidx) {
-                    ast::ValType::I32 => runtime.stack.push(runtime.stack.read::<i32>(addr)),
-                    ast::ValType::I64 => runtime.stack.push(runtime.stack.read::<i64>(addr)),
-                    ast::ValType::F32 => runtime.stack.push(runtime.stack.read::<f32>(addr)),
-                    ast::ValType::F64 => runtime.stack.push(runtime.stack.read::<f64>(addr)),
-                }
+                runtime.stack.read_local(*localidx);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-set
             LocalSet(localidx) => {

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -574,16 +574,14 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-set
             LocalSet(localidx) => {
-                let addr = runtime.stack.local_addr(*localidx);
                 let val = runtime.stack.pop();
-                runtime.stack.write_any(addr, val);
+                runtime.stack.write_any(*localidx, val);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-tee
             LocalTee(localidx) => {
                 // Like local.set, but it does not change stack
-                let addr = runtime.stack.local_addr(*localidx);
                 let val = runtime.stack.top();
-                runtime.stack.write_any(addr, val);
+                runtime.stack.write_any(*localidx, val);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-global-get
             GlobalGet(globalidx) => match runtime.module.ast.globals[*globalidx as usize].ty {

--- a/wain-exec/src/runtime.rs
+++ b/wain-exec/src/runtime.rs
@@ -575,13 +575,13 @@ impl<'m, 's, I: Importer> Execute<'m, 's, I> for ast::Instruction {
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-set
             LocalSet(localidx) => {
                 let val = runtime.stack.pop();
-                runtime.stack.write_any(*localidx, val);
+                runtime.stack.write_local(*localidx, val);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-local-tee
             LocalTee(localidx) => {
                 // Like local.set, but it does not change stack
                 let val = runtime.stack.top();
-                runtime.stack.write_any(*localidx, val);
+                runtime.stack.write_local(*localidx, val);
             }
             // https://webassembly.github.io/spec/core/exec/instructions.html#exec-global-get
             GlobalGet(globalidx) => match runtime.module.ast.globals[*globalidx as usize].ty {

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -182,6 +182,16 @@ impl Stack {
         }
     }
 
+    pub fn read_local(&mut self, localidx: u32) {
+        let addr = self.local_addr(localidx);
+        match self.local_type(localidx) {
+            ValType::I32 => self.push(self.read::<i32>(addr)),
+            ValType::I64 => self.push(self.read::<i64>(addr)),
+            ValType::F32 => self.push(self.read::<f32>(addr)),
+            ValType::F64 => self.push(self.read::<f64>(addr)),
+        }
+    }
+
     fn top_addr(&self) -> usize {
         self.bytes.len()
     }

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -172,7 +172,7 @@ impl Stack {
         LittleEndian::read(&self.bytes, addr)
     }
 
-    pub fn write_any(&mut self, localidx: u32, v: Value) {
+    pub fn write_local(&mut self, localidx: u32, v: Value) {
         let addr = self.local_addr(localidx);
         match v {
             Value::I32(i) => self.write(addr, i),

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -172,9 +172,9 @@ impl Stack {
         LittleEndian::read(&self.bytes, addr)
     }
 
-    pub fn write_local(&mut self, localidx: u32, v: Value) {
+    pub fn write_local(&mut self, localidx: u32) {
         let addr = self.local_addr(localidx);
-        match v {
+        match self.top() {
             Value::I32(i) => self.write(addr, i),
             Value::I64(i) => self.write(addr, i),
             Value::F32(f) => self.write(addr, f),

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -172,7 +172,8 @@ impl Stack {
         LittleEndian::read(&self.bytes, addr)
     }
 
-    pub fn write_any(&mut self, addr: usize, v: Value) {
+    pub fn write_any(&mut self, localidx: u32, v: Value) {
+        let addr = self.local_addr(localidx);
         match v {
             Value::I32(i) => self.write(addr, i),
             Value::I64(i) => self.write(addr, i),

--- a/wain-exec/src/stack.rs
+++ b/wain-exec/src/stack.rs
@@ -164,11 +164,11 @@ impl Stack {
         self.write_top_type(V::VAL_TYPE);
     }
 
-    pub fn write<V: LittleEndian>(&mut self, addr: usize, v: V) {
+    fn write<V: LittleEndian>(&mut self, addr: usize, v: V) {
         LittleEndian::write(&mut self.bytes, addr, v);
     }
 
-    pub fn read<V: LittleEndian>(&self, addr: usize) -> V {
+    fn read<V: LittleEndian>(&self, addr: usize) -> V {
         LittleEndian::read(&self.bytes, addr)
     }
 
@@ -257,11 +257,11 @@ impl Stack {
         self.frame = prev_frame;
     }
 
-    pub fn local_addr(&self, localidx: u32) -> usize {
+    fn local_addr(&self, localidx: u32) -> usize {
         self.frame.local_addrs[localidx as usize]
     }
 
-    pub fn local_type(&self, localidx: u32) -> ValType {
+    fn local_type(&self, localidx: u32) -> ValType {
         let idx = localidx as usize;
         self.types[self.frame.base_idx + idx]
     }


### PR DESCRIPTION
`Runtime` からローカル変数の読み書きを行う際にアドレス（オフセット）を使用していましたが、インデックスからアドレス（オフセット）への変換テーブルも `Stack` 内に持っているので、`Runtime` からローカル変数を指定する際にはインデックスを指定するように変更しました。
これによって、`Stack` の外部でアドレス（オフセット）を直接使用する必要が無くなりました。

また、ローカル変数の読み出し先、書き込み元もスタックなので、引数や戻り値ではなく直接スタックとやり取りするようにしました。（`Stack::write_any`、`Stack::read_any`）
若干微妙な感じがしないでもないですが、後でこれらのメソッドに `slice::copy_within` を使うための布石です。